### PR TITLE
Revisão: "Política_de_Plano_de_Recuperação_de_Desastres"

### DIFF
--- a/Política_de_Plano_de_Recuperação_de_Desastres.md
+++ b/Política_de_Plano_de_Recuperação_de_Desastres.md
@@ -1,47 +1,71 @@
-**Política de Plano de Recuperação de Desastres**
+# Política de Plano de Recuperação de Desastres
 
-**1. Visão Geral**
-Uma vez que desastres acontecem com pouca frequência, a administração muitas vezes ignora o processo de planejamento de recuperação de desastres. É importante perceber que ter um plano de contingência em caso de desastre confere à <Nome da Empresa> uma vantagem competitiva. Esta política exige que a administração apoie financeiramente e participe diligentemente dos esforços de planejamento de contingência para desastres. Os desastres não se limitam às condições climáticas adversas. Qualquer evento que possa causar um atraso prolongado no serviço deve ser considerado. O Plano de Recuperação de Desastres é frequentemente parte do Plano de Continuidade de Negócios.
+**Aviso de Uso Livre:** Esta política foi criada pela SANS Institute para a comunidade da Internet. Toda ou parte desta política pode ser livremente usada pela sua organização. Não é necessária aprovação prévia. Se desejar contribuir com uma nova política ou uma versão atualizada desta política, envie um e-mail para policy-resources@sans.org.
 
-**2. Propósito**
+**Status da Última Atualização:** Atualizado em junho de 2014.
+
+# 1. Visão Geral
+
+Uma vez que desastres acontecem com pouca frequência, a administração muitas vezes ignora o processo de planejamento de recuperação de desastres. É importante perceber que ter um plano de contingência em caso de desastre confere à <Nome da Empresa> uma vantagem competitiva. Esta política exige que a administração apoie financeiramente e participe diligentemente dos esforços de planejamento de contingência para desastres. Desastres não se limitam às condições climáticas adversas. Qualquer evento que possa causar um atraso prolongado no serviço deve ser considerado. O Plano de Recuperação de Desastres geralmente faz parte do Plano de Continuidade de Negócios.
+
+# 2. Propósito
+
 Esta política define a exigência de um plano de recuperação de desastres básico a ser desenvolvido e implementado pela <Nome da Empresa> que descreverá o processo de recuperação de Sistemas de TI, Aplicativos e Dados de qualquer tipo de desastre que cause uma grande interrupção.
 
-**3. Abrangência**
+# 3. Abrangência
+
 Esta política é direcionada à equipe de Gerenciamento de TI, que é responsável por garantir que o plano seja desenvolvido, testado e mantido atualizado. Esta política se limita a estabelecer a exigência de ter um plano de recuperação de desastres, não estabelecendo requisitos sobre o que deve ser incluído no plano ou subplanos.
 
-**4. Política**
-**4.1 Planos de Contingência**
+# 4. Política
+
+## 4.1 Planos de Contingência
+
 Os seguintes planos de contingência devem ser criados:
-- **Plano de Resposta a Emergências em Computadores:** Quem deve ser contatado, quando e como? Quais ações imediatas devem ser tomadas em caso de determinados eventos?
-- **Plano de Sucessão:** Descrever o fluxo de responsabilidade quando os funcionários normais não estão disponíveis para realizar suas funções.
-- **Estudo de Dados:** Detalhar os dados armazenados nos sistemas, sua importância crítica e confidencialidade.
-- **Lista de Criticidade dos Serviços:** Listar todos os serviços prestados e sua ordem de importância.
-- **Ele também explica a ordem de recuperação em prazos de curto e longo prazo.**
-- **Plano de Backup e Restauração de Dados:** Detalhar quais dados são copiados, o meio no qual são salvos, onde esse meio é armazenado e com que frequência o backup é realizado. Também deve descrever como esses dados podem ser recuperados.
-- **Plano de Substituição de Equipamentos:** Descrever quais equipamentos são necessários para começar a fornecer serviços, listar a ordem em que são necessários e anotar onde comprar o equipamento.
+
+- **Plano de Resposta a Emergências Computacionais:** Quem deve ser contatado, quando e como? Quais ações imediatas devem ser tomadas em caso de determinados eventos?
+
+- **Plano de Sucessão:** Descrever o fluxo de responsabilidade quando os funcionários ordinários não estão disponíveis para realizar suas funções.
+
+- **Estudo de Dados:** Detalhar os dados armazenados nos sistemas, sua importância e confidencialidade.
+
+- **Lista de Importância dos Serviços:** Listar todos os serviços prestados e sua ordem de importância. Também explica a ordem de recuperação em curto e longo prazo.
+
+- **Plano de Backup e Restauração de Dados:** Detalhar quais dados possuem backup, o meio no qual são salvos, onde esse meio é armazenado e com que frequência o backup é realizado. Também deve descrever como esses dados podem ser recuperados.
+
+- **Plano de Substituição de Equipamentos:** Descrever quais equipamentos são necessários para começar a fornecer serviços, listar a ordem em que são necessários e mencionar onde comprar o equipamento.
+
 - **Gestão de Mídia de Massa:** Quem é responsável por fornecer informações à mídia de massa? Também fornecer algumas diretrizes sobre quais dados são apropriados para serem fornecidos.
-Após a criação dos planos, é importante praticá-los na medida do possível. A administração deve reservar um tempo para testar a implementação do plano de recuperação de desastres. Exercícios de mesa devem ser conduzidos anualmente. Durante esses testes, problemas que possam fazer o plano falhar podem ser descobertos e corrigidos em um ambiente com poucas consequências.
+
+Após a criação dos planos, é importante praticá-los na medida do possível. A administração deve reservar um tempo para testar a implementação do plano de recuperação de desastres. Exercícios teóricos devem ser conduzidos anualmente. Durante esses testes, problemas que possam fazer o plano falhar podem ser descobertos e corrigidos em um ambiente com poucas consequências.
 
 O plano, no mínimo, deve ser revisado e atualizado anualmente.
 
-**5. Cumprimento da Política**
-**5.1 Medição de Cumprimento**
+# 5. Conformidade com a Política
+
+## 5.1 Medição da Conformidade
+
 A equipe de Segurança da Informação verificará o cumprimento desta política por meio de vários métodos, incluindo, mas não se limitando a verificações periódicas, monitoramento por vídeo, relatórios de ferramentas de negócios, auditorias internas e externas e feedback ao proprietário da política.
 
-**5.2 Exceções**
+## 5.2 Exceções
+
 Qualquer exceção a esta política deve ser aprovada antecipadamente pela equipe de Segurança da Informação.
 
-**5.3 Não Cumprimento**
+## 5.3 Não Conformidade
+
 Um funcionário que violar esta política pode estar sujeito a ação disciplinar, incluindo a rescisão do emprego.
 
-**6. Padrões, Políticas e Processos Relacionados**
+## 6. Normas, Políticas e Processos Relacionados
+
 Nenhum.
 
-**7. Definições e Termos**
-A seguinte definição e termos podem ser encontrados no Glossário do SANS localizado em: [Glossário do SANS](https://www.sans.org/security-resources/glossary-of-terms/)
-- **Desastre**
+## 7. Definições e Termos
 
-**8. Histórico de Revisões**
-Data da Alteração	Responsável	Sumário da Alteração
-Junho de 2014	Equipe de Políticas SANS	Atualizado e convertido para o novo formato.
-Outubro de 2023 Equipe de Tradução IFPB Tradução para Português do Brasil.
+A seguinte definição e termos podem ser encontrados no Glossário do SANS localizado em: https://www.sans.org/security-resources/glossary-of-terms/
+- Desastre
+
+## 8. Histórico de Revisões
+
+Data da Alteração | Responsável | Resumo da Alteração
+--- | --- | ---
+Junho de 2014 | Equipe de Políticas da SANS | Atualizada e convertida para o novo formato.
+Outubro de 2023 | Equipe de Tradução IFPB | Traduzida para Português do Brasil.


### PR DESCRIPTION
Dúvidas:

O documeto que tu passou como exemplo coloca o status da última atualização para junho de 2014, mas não era pra colocarmos outubro de 2023, já que no final dos documentos no histórico de revisões tem: "Outubro de 2023 Equipe de Tradução IFPB Tradução para Português do Brasil."?

4.1:

No final dessa seção em "Table top exercises" foi traduzido pelo chat como "Exercícios de mesa". Achei uma outra tradução menos literal online e coloquei "exercicios teoricos", mas fiquei na dúvida se realmente se encaixa melhor, if at all.

5.1:

O chat dessa vez, ao invés de manter "Infosec", traduziu como "equipe de Segurança da Informação". Quando olhei no documento que foi nos dado como exemplo, nele está como "A equipe de Segurança da Informação (Infosec)", já no documento que traduzi previamente eu deixei como apenas "Infosec". Queria saber qual vai ser o padrão adotado pelo time daqui pra frente pra atualizar tanto esse documento como o que traduzi previamente com ele.



Observações:

4.1:

- **Lista de Importância dos Serviços:** Listar todos os serviços prestados e sua ordem de importância. Também explica a ordem de recuperação em curto e longo prazo.

Essa parte no documento original estava separada em duas seções distintas como:

- Criticality of Service List: List all the services provided and their order of importance.
- It also explains the order of recovery in both short-term and long-term timeframes.

Mas como a segunda não tinha ":" e parecia ser uma continuação da primeira, juntei as duas em uma só.

Mesma coisa foi feita com:

- **Gestão de Mídia de Massa:** Quem é responsável por fornecer informações à mídia de massa? Também fornecer algumas diretrizes sobre quais dados são apropriados para serem fornecidos.

Que antes era:

- Mass Media Management: Who is in charge of giving information to the mass media?
- Also provide some guidelines on what data is appropriate to be provided.